### PR TITLE
have social links open in new tab

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default class ReactSimpleShare extends Component {
     const links = sites.map(site => {
       return (
         <li key={site}>
-          <a href={getShareLink(site, url, title)}>
+          <a href={getShareLink(site, url, title)} target="_blank">
             {getShareIcon(site, width, height, color, theme)}
           </a>
         </li>


### PR DESCRIPTION
I think this would be a more effective way to handle on a mobile website. open a new tab in whatever browser instead of taking a user away from the page their on.